### PR TITLE
Find CUPS and link to it explicitly

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -98,6 +98,7 @@ set(CMAKE_BUILD_TYPE Debug)
 
 SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 find_package(Qt4 REQUIRED)
+find_package(Cups REQUIRED)
 find_package(Ghostscript REQUIRED)
 
 include_directories(
@@ -106,6 +107,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/third-party/libspectre
     ${CMAKE_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
+    ${CUPS_INCLUDE_DIR}
     ${GHOSTSCRIPT_INCLUDES}
 )
 
@@ -121,7 +123,7 @@ get_translatorsinfo_qrc(translatorsinfo_qrc)
 qt4_add_resources(QRC_CXX_SOURCES ${translatorsinfo_qrc})
 
 add_executable(boomaga ${HEADERS} ${SOURCES} ${MOC_SOURCES} ${QM_FILES} ${QRC_SOURCES} ${UI_HEADERS} ${QRC_CXX_SOURCES})
-target_link_libraries(boomaga ${LIBRARIES} ${QT_LIBRARIES} ${GHOSTSCRIPT_LIBRARIES})
+target_link_libraries(boomaga ${LIBRARIES} ${QT_LIBRARIES} ${CUPS_LIBRARIES} ${GHOSTSCRIPT_LIBRARIES})
 
 install(TARGETS boomaga RUNTIME DESTINATION ${GUI_DIR})
 install(FILES ${QM_FILES} DESTINATION ${TRANSLATIONS_DIR})


### PR DESCRIPTION
Fixes linking error:

```
...
[100%] Building CXX object gui/CMakeFiles/boomaga.dir/qrc_translatorsinfo.cxx.o
Linking CXX executable boomaga
/tmp/boomaga/gui/kernel/printer.cpp:134: error: undefined reference to 'cupsGetDests'
/tmp/boomaga/gui/kernel/printer.cpp:136: error: undefined reference to 'cupsGetDest'
/tmp/boomaga/gui/kernel/printer.cpp:145: error: undefined reference to 'cupsGetOption'
/tmp/boomaga/gui/kernel/printer.cpp:146: error: undefined reference to 'cupsGetOption'
/tmp/boomaga/gui/kernel/printer.cpp:151: error: undefined reference to 'cupsGetPPD'
/tmp/boomaga/gui/kernel/printer.cpp:152: error: undefined reference to 'ppdOpenFile'
/tmp/boomaga/gui/kernel/printer.cpp:155: error: undefined reference to 'ppdMarkDefaults'
/tmp/boomaga/gui/kernel/printer.cpp:157: error: undefined reference to 'ppdPageSize'
/tmp/boomaga/gui/kernel/printer.cpp:166: error: undefined reference to 'ppdClose'
/tmp/boomaga/gui/kernel/printer.cpp:174: error: undefined reference to 'cupsGetOption'
/tmp/boomaga/gui/kernel/printer.cpp:178: error: undefined reference to 'cupsGetOption'
/tmp/boomaga/gui/kernel/printer.cpp:190: error: undefined reference to 'cupsFreeDests'
collect2: error: ld returned 1 exit status
make[2]: *** [gui/boomaga] Error 1
make[1]: *** [gui/CMakeFiles/boomaga.dir/all] Error 2
make: *** [all] Error 2
```
