### PR TITLE
Add grayscale printing option

### DIFF
--- a/gui/kernel/project.cpp
+++ b/gui/kernel/project.cpp
@@ -82,6 +82,7 @@ Project::Project(QObject *parent) :
     mNullPrinter("Fake"),
     mPrinter(&mNullPrinter),
     mDoubleSided(true),
+    mGrayscale(false),
     mRotation(NoRotate)
 {
 }
@@ -111,7 +112,7 @@ void Project::free()
  ************************************************/
 TmpPdfFile *Project::createTmpPdfFile()
 {
-    TmpPdfFile *res = new TmpPdfFile(mJobs, this);
+    TmpPdfFile *res = new TmpPdfFile(mJobs, mGrayscale, this);
 
     connect(res, SIGNAL(progress(int,int)),
             this, SLOT(tmpFileProgress(int,int)));
@@ -614,6 +615,19 @@ void Project::setDoubleSided(bool value)
 {
     mDoubleSided = value;
     emit changed();
+}
+
+
+/************************************************
+ *
+ ************************************************/
+void Project::setGrayscale(bool value)
+{
+    mGrayscale = value;
+    update();
+
+    mLastTmpFile = createTmpPdfFile();
+    mLastTmpFile->merge();
 }
 
 

--- a/gui/kernel/project.h
+++ b/gui/kernel/project.h
@@ -162,6 +162,7 @@ public slots:
     void moveJob(int from, int to);
     void setLayout(const Layout *layout);
     void setDoubleSided(bool value);
+    void setGrayscale(bool value);
     void update();
 
 
@@ -199,6 +200,7 @@ private:
     Printer mNullPrinter;
     Printer *mPrinter;
     bool mDoubleSided;
+    bool mGrayscale;
 
     MetaData mMetaData;
     Rotation mRotation;

--- a/gui/kernel/tmppdffile.h
+++ b/gui/kernel/tmppdffile.h
@@ -45,7 +45,7 @@ class TmpPdfFile: public QObject
     Q_OBJECT
     friend class PdfMerger;
 public:
-    explicit TmpPdfFile(const JobList &jobs, QObject *parent = 0);
+    explicit TmpPdfFile(const JobList &jobs, bool grayscale = false, QObject *parent = 0);
     virtual ~TmpPdfFile();
 
     void merge();
@@ -78,6 +78,8 @@ private:
 
     static QString genFileName();
 
+    QString createTmpGrayscaleFile(QString fileName);
+
     QList<InputFile> mInputFiles;
     QHash<QString, PdfPageInfo> mPagesInfo;
 
@@ -87,6 +89,9 @@ private:
     qint64 mOrigXrefPos;
     QProcess *mMerger;
     bool mValid;
+
+    QList<QString> mTmpFileNames;
+    bool mGrayscale;
 };
 
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -134,6 +134,9 @@ MainWindow::MainWindow(QWidget *parent):
     connect(ui->doubleSidedCbx, SIGNAL(clicked(bool)),
             project, SLOT(setDoubleSided(bool)));
 
+    connect(ui->grayscaleCbx, SIGNAL(clicked(bool)),
+            project, SLOT(setGrayscale(bool)));
+
     connect(ui->jobsView, SIGNAL(sheetSelected(int)),
             project, SLOT(setCurrentSheet(int)));
 

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -117,6 +117,16 @@
              </property>
             </widget>
            </item>
+           <item>
+            <widget class="QCheckBox" name="grayscaleCbx">
+             <property name="toolTip">
+              <string comment="MainForm::Grayscale checkbox tooltip">Print in grayscale</string>
+             </property>
+             <property name="text">
+              <string comment="MainForm::Grayscale checkbox">Grayscale</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
         </item>


### PR DESCRIPTION
Add grayscale option by converting input file to grayscale using
ghostscript right before feeding into boomagamerger. It seem to work
well for most cases.

Possible problems:
- Converted input file does not take care of endPos of InputFile
- Translation files

Side note: I tried to put the conversion at the constructor of
TmpPdfFile but it does not work. Diffing the outputs shows the wrong
references in XObject e.g. Im0. This is due to
TmpPdfFile::writeSheets() called by TmpPdfFile::updateSheets() inside
Project::update().

This commit may cause problems. Codes for the new feature may not be
added at the best places. Please advise.

Resolves: #36
