### PR TITLE
Cups backend: EnvInfo - fix partial key matches

### DIFF
--- a/cups/envinfo.cpp
+++ b/cups/envinfo.cpp
@@ -123,6 +123,9 @@ QString getValue(const QByteArray &data, const QString &key)
     if (b < 0)
         return "";
 
+    if (b > 0)
+	b = data.indexOf('\x0' + key + "=") + 1;
+
     b += key.length() + 1;
     int e = data.indexOf('\x0', b);
     if (e < 0)


### PR DESCRIPTION
If we are not at the start of the byte array
check a null characte separator precedes the key
we match.

---

The gui failed to load:

```
qt.qpa.screen: QXcbConnection: Could not connect to display wayland-0
Could not connect to any X display.
```

Somehow firefox 57 had:
```
WAYLAND_DISPLAY=wayland-0
DISPLAY=:0
```
that is {WAYLAND_}DISPLAY=wayland-0 matched the key DISPLAY=.

You might want to sync this to the  getValue in Q_OS_FREEBSD section.

The idea of the fix is if we are not the first key in the byte array then b is strictly greater than zero and we could check there is a null character one byte below. We add one to the position of the key to account for the null character we grab.

Most processes have DISPLAY before WAYLAND_DISPLAY ... so most of the time all is fine. 
