### PR TITLE
Fix typos.

### DIFF
--- a/src/backend/cups_backend/main.cpp
+++ b/src/backend/cups_backend/main.cpp
@@ -69,7 +69,7 @@ static int getmod(const string &file)
  ************************************************/
 static string mkUserDir(const string &baseDir, const string &user)
 {
-    Log::debug("Create user direcory %s", baseDir.c_str());
+    Log::debug("Create user directory %s", baseDir.c_str());
 
     passwd *pwd = getpwnam(user.c_str());
     if (!pwd)

--- a/src/boomaga/finddbusaddress.cpp
+++ b/src/boomaga/finddbusaddress.cpp
@@ -82,7 +82,7 @@ QStringList FindDbusAddress::fromSessionFiles()
     DIR *dir;
     if ((dir = opendir(sessionsDir.c_str())) == NULL)
     {
-        Log::warn("Can't read DBUS session direcory %s", sessionsDir.c_str());
+        Log::warn("Can't read DBUS session directory %s", sessionsDir.c_str());
         return QStringList();
     }
 
@@ -133,7 +133,7 @@ QStringList FindDbusAddress::fromProcFiles()
     DIR *dir;
     if ((dir = opendir(PROC_DIR.c_str())) == NULL)
     {
-        Log::warn("Can't read /proc direcory");
+        Log::warn("Can't read /proc directory");
         return QStringList();
     }
 

--- a/src/boomaga/gui/printersettings/printersettings.cpp
+++ b/src/boomaga/gui/printersettings/printersettings.cpp
@@ -355,7 +355,7 @@ void PrinterSettings::addProfile()
     QStandardItem *parent = cur->parent();
 
     ProfileItem *item =new ProfileItem();
-    item->setText(tr("Profile %1", "Defaul name for created printer profile in the Printer Settings diaog")
+    item->setText(tr("Profile %1", "Default name for created printer profile in the Printer Settings diaog")
                   .arg(parent->rowCount()));
     parent->insertRow(cur->row()+1, item);
 

--- a/src/boomaga/translations/boomaga_cs.ts
+++ b/src/boomaga/translations/boomaga_cs.ts
@@ -632,7 +632,7 @@ Jste si jistý, že jej chcete přepsat?</translation>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation>Profil %1</translation>
     </message>
     <message>

--- a/src/boomaga/translations/boomaga_de.ts
+++ b/src/boomaga/translations/boomaga_de.ts
@@ -632,7 +632,7 @@ Sind Sie sicher, dass diese überschrieben werden soll?</translation>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation>Profil %1</translation>
     </message>
     <message>

--- a/src/boomaga/translations/boomaga_el.ts
+++ b/src/boomaga/translations/boomaga_el.ts
@@ -632,7 +632,7 @@ Are you sure you want to overwrite it?</source>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation>Ταυτότητα %1</translation>
     </message>
     <message>

--- a/src/boomaga/translations/boomaga_eu.ts
+++ b/src/boomaga/translations/boomaga_eu.ts
@@ -632,7 +632,7 @@ Gainidatzi?</translation>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/boomaga/translations/boomaga_fr.ts
+++ b/src/boomaga/translations/boomaga_fr.ts
@@ -632,7 +632,7 @@ Are you sure you want to overwrite it?</source>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation>Profil %1</translation>
     </message>
     <message>

--- a/src/boomaga/translations/boomaga_hu_HU.ts
+++ b/src/boomaga/translations/boomaga_hu_HU.ts
@@ -632,7 +632,7 @@ Biztosan felül szeretné írni?</translation>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation>%1 profil</translation>
     </message>
     <message>

--- a/src/boomaga/translations/boomaga_it.ts
+++ b/src/boomaga/translations/boomaga_it.ts
@@ -632,7 +632,7 @@ Sei sicuro di volerlo sovracrivere?</translation>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation>Profilo %1</translation>
     </message>
     <message>

--- a/src/boomaga/translations/boomaga_lt.ts
+++ b/src/boomaga/translations/boomaga_lt.ts
@@ -632,7 +632,7 @@ Ar tikrai norite pakeisti šį failą?</translation>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation>Profilis %1</translation>
     </message>
     <message>

--- a/src/boomaga/translations/boomaga_nb_NO.ts
+++ b/src/boomaga/translations/boomaga_nb_NO.ts
@@ -632,7 +632,7 @@ Er du sikker på at du vil overskrive den?</translation>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation>Profil %1</translation>
     </message>
     <message>

--- a/src/boomaga/translations/boomaga_nl_NL.ts
+++ b/src/boomaga/translations/boomaga_nl_NL.ts
@@ -632,7 +632,7 @@ Weet u zeker dat u dit wilt overschrijven?</translation>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation>Profiel %1</translation>
     </message>
     <message>

--- a/src/boomaga/translations/boomaga_pl_PL.ts
+++ b/src/boomaga/translations/boomaga_pl_PL.ts
@@ -631,7 +631,7 @@ Are you sure you want to overwrite it?</source>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/boomaga/translations/boomaga_ro.ts
+++ b/src/boomaga/translations/boomaga_ro.ts
@@ -632,7 +632,7 @@ Sunteți siguri că doriți să-l suprascrieți?</translation>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation>Profilul %1</translation>
     </message>
     <message>

--- a/src/boomaga/translations/boomaga_ru.ts
+++ b/src/boomaga/translations/boomaga_ru.ts
@@ -632,7 +632,7 @@ Are you sure you want to overwrite it?</source>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation>Профиль %1</translation>
     </message>
     <message>

--- a/src/boomaga/translations/boomaga_uk_UA.ts
+++ b/src/boomaga/translations/boomaga_uk_UA.ts
@@ -632,7 +632,7 @@ Are you sure you want to overwrite it?</source>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation>Профіль: %1</translation>
     </message>
     <message>

--- a/src/boomaga/translations/boomaga_uz@Latn.ts
+++ b/src/boomaga/translations/boomaga_uz@Latn.ts
@@ -631,7 +631,7 @@ Are you sure you want to overwrite it?</source>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/boomaga/translations/src.boomaga.ts
+++ b/src/boomaga/translations/src.boomaga.ts
@@ -633,7 +633,7 @@ Are you sure you want to overwrite it?</source>
     </message>
     <message>
         <source>Profile %1</source>
-        <comment>Defaul name for created printer profile in the Printer Settings diaog</comment>
+        <comment>Default name for created printer profile in the Printer Settings diaog</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
This are typos found by lintian while updating the Debian package.

Defaul → Default
direcory → directoy.