### PR TITLE
Fix incompatibility with GhostScript 9.54

### DIFF
--- a/src/boomaga/iofiles/postscriptfile.cpp
+++ b/src/boomaga/iofiles/postscriptfile.cpp
@@ -73,7 +73,6 @@ void PostScriptFile::convertToPdf(QFile &psFile, const QString &pdfFile)
     args << "-sDEVICE=pdfwrite";
     args << "-sOutputFile=" + pdfFile;
     args << "-q";
-    args << "-c" << ".setpdfwrite";
     args << "-f" << "-";
 
 


### PR DESCRIPTION
Fixes #107. See the related issue for more information.

Maybe adding `-c '3000000 setvmthreshold'` would also be a good option, but I don't know whether it's really needed in Boomaga. Also I didn't check the compatibility of the fix with GhostScript < 9.50, where this option was not deprecated. However, it has always been just recommended, and GhostScript 9.50 was released in 2019, so maybe it's still good to use with earlier versions of GhostScript.

Any other suggestions are welcome.